### PR TITLE
Some fixes

### DIFF
--- a/OAuth_2/OAuth2PHPExample.php
+++ b/OAuth_2/OAuth2PHPExample.php
@@ -2,8 +2,11 @@
 require("./Client.php");
 $configs = include('./config.php');
 
-session_start();
-
+$session_id = session_id();
+if (empty($session_id))
+{
+    session_start();
+}
 $authorizationRequestUrl = $configs['authorizationRequestUrl'];
 $tokenEndPointUrl = $configs['tokenEndPointUrl'];
 $client_id = $configs['client_id'];

--- a/OAuth_2/OAuthOpenIDExample.php
+++ b/OAuth_2/OAuthOpenIDExample.php
@@ -1,20 +1,17 @@
 <?php
-if (isset($_GET["code"])) {
-?>
-    <script
-        type="text/javascript"
-        src="https://appcenter.intuit.com/Content/IA/intuit.ipp.anywhere-1.3.3.js">
-    </script>
-<?php
+$session_id = session_id();
+if (empty($session_id))
+{
+    session_start();
 }
-?>
-
-<?php
 require("./Client.php");
 $configs = include('./config.php');
-
-session_start();
-
+if (isset($_GET["code"])) {
+    echo '<script
+        type="text/javascript"
+        src="https://appcenter.intuit.com/Content/IA/intuit.ipp.anywhere-1.3.3.js">
+    </script>';
+}
 $mainPage = $configs['mainPage'];
 
 $client_id = $configs['client_id'];

--- a/OAuth_2/RefreshToken.php
+++ b/OAuth_2/RefreshToken.php
@@ -2,8 +2,11 @@
 require("./Client.php");
 $configs = include('./config.php');
 
-session_start();
-
+$session_id = session_id();
+if (empty($session_id))
+{
+    session_start();
+}
 $tokenEndPointUrl = $configs['tokenEndPointUrl'];
 $mainPage = $configs['mainPage'];
 $client_id = $configs['client_id'];

--- a/OAuth_2/RefreshToken.php
+++ b/OAuth_2/RefreshToken.php
@@ -11,7 +11,8 @@ $client_secret = $configs['client_secret'];
 
 
 $grant_type= 'refresh_token';
-$certFilePath = './Certificate/all.platform.intuit.com.pem';
+//$certFilePath = './Certificate/all.platform.intuit.com.pem';
+$certFilePath = './Certificate/cacert.pem';
 
 
 $refresh_token = $_SESSION['refresh_token'];

--- a/OAuth_2/index.php
+++ b/OAuth_2/index.php
@@ -1,10 +1,15 @@
-<html>
 <?php
+$session_id = session_id();
+if (empty($session_id))
+{
+    session_start();
+}
 $configs = include('./config.php');
 $redirect_uri = $configs['oauth_redirect_uri'];
 $openID_redirect_uri = $configs['openID_redirect_uri'];
 $refreshTokenPage = $configs['refreshTokenPage'];
  ?>
+<html>
  <script
       type="text/javascript"
       src="https://appcenter.intuit.com/Content/IA/intuit.ipp.anywhere-1.3.3.js">
@@ -29,7 +34,7 @@ $refreshTokenPage = $configs['refreshTokenPage'];
 
 
 <?php
-  session_start();
+
   if(isset($_SESSION['access_token']) && !empty($_SESSION['access_token'])){
     echo "<h3>Retrieve OAuth 2 Tokens from Sessions:</h3>";
     $tokens = array(


### PR DESCRIPTION
Test for session ID added and only if none exists should session_start() be called. 
OAuthOpenIDExample.php was not working.  Modified code so that first javascript block is echoed.
RefreshToken.php had incorrect cert set.